### PR TITLE
datetime conversion report filter

### DIFF
--- a/dracoon/reports/__init__.py
+++ b/dracoon/reports/__init__.py
@@ -33,15 +33,17 @@ class DRACOONReports:
     """
 
     def __init__(self, dracoon_client: DRACOONClient):
-        """ requires a DRACOONClient to perform any request """
+        """requires a DRACOONClient to perform any request"""
         if not isinstance(dracoon_client, DRACOONClient):
-            raise InvalidClientError(message='Invalid client')
-        
-        self.logger = logging.getLogger('dracoon.reports')
-        
+            raise InvalidClientError(message="Invalid client")
+
+        self.logger = logging.getLogger("dracoon.reports")
+
         if dracoon_client.connection:
             self.dracoon = dracoon_client
-            self.api_url = self.dracoon.base_url + self.dracoon.reporting_base_url + '/reports'
+            self.api_url = (
+                self.dracoon.base_url + self.dracoon.reporting_base_url + "/reports"
+            )
             if self.dracoon.raise_on_err:
                 self.raise_on_err = True
             else:
@@ -49,11 +51,15 @@ class DRACOONReports:
 
         else:
             self.logger.error("DRACOON client error: no connection. ")
-            raise ClientDisconnectedError(message='DRACOON client must be connected: client.connect()')
+            raise ClientDisconnectedError(
+                message="DRACOON client must be connected: client.connect()"
+            )
 
     @retry(**RETRY_CONFIG)
-    async def create_report(self, report: CreateReport, raise_on_err: bool = False) -> None:
-        """ create a new report """
+    async def create_report(
+        self, report: CreateReport, raise_on_err: bool = False
+    ) -> None:
+        """create a new report"""
         payload = report.dict(exclude_unset=True)
 
         if not await self.dracoon.test_connection() and self.dracoon.connection:
@@ -71,64 +77,99 @@ class DRACOONReports:
         except httpx.HTTPStatusError as e:
             self.logger.error("Creating report failed.")
             await self.dracoon.handle_http_error(err=e, raise_on_err=raise_on_err)
-        
+
         self.logger.info("Created report.")
         return None
-    
-    def make_report(self, name: str, target_id: int, formats: List[ReportFormat], type: ReportType = ReportType.single, 
-                    sub_type: ReportSubType = ReportSubType.audit_report, 
-                    enabled: bool = None, filter: ReportFilter = None) -> CreateReport:
-        """ make a report payload to generate a report """
+
+    def make_report(
+        self,
+        name: str,
+        target_id: int,
+        formats: List[ReportFormat],
+        type: ReportType = ReportType.single,
+        sub_type: ReportSubType = ReportSubType.audit_report,
+        enabled: bool = None,
+        filter: ReportFilter = None,
+    ) -> CreateReport:
+        """make a report payload to generate a report"""
         report = {
             "name": name,
-            "target": {
-                "id": target_id
-            },
+            "target": {"id": target_id},
             "type": type,
             "subType": sub_type,
-            "formats": formats  
+            "formats": formats,
         }
 
-        if enabled is not None: report["enabled"] = enabled
-        if filter: report["filter"] = filter
+        if enabled is not None:
+            report["enabled"] = enabled
+        if filter:
+            report["filter"] = filter
 
         return CreateReport(**report)
 
-
-    def make_report_filter(self, from_date: datetime = None, to_date: datetime = None, parent_room_id: int = None, 
-                           user_id: int = None, operations: List[int] = None) -> ReportFilter:
-        """ make an optional report filter needed for make_report() """
+    def make_report_filter(
+        self,
+        from_date: datetime = None,
+        to_date: datetime = None,
+        parent_room_id: int = None,
+        user_id: int = None,
+        operations: List[int] = None,
+    ) -> ReportFilter:
+        """make an optional report filter needed for make_report()"""
 
         filter = {}
 
-        if from_date: filter["fromDate"] = from_date
-        if to_date: filter["toDate"] = to_date
-        if parent_room_id: filter["parentRoom"] = parent_room_id
-        if user_id: filter["userId"] = user_id
-        if operations: filter["operations"] = operations
+        if from_date:
+            filter["fromDate"] = from_date.isoformat(timespec="milliseconds") + "Z"
+        if to_date:
+            filter["toDate"] = to_date.isoformat(timespec="milliseconds") + "Z"
+        if parent_room_id:
+            filter["parentRoom"] = parent_room_id
+        if user_id:
+            filter["userId"] = user_id
+        if operations:
+            filter["operations"] = operations
 
         return ReportFilter(**filter)
-    
+
     @retry(**RETRY_CONFIG)
-    async def get_reports(self, name: str = None, type: str = None, sub_type: str = None, state: str = None, 
-                has_error: bool = None, enabled: bool = None, 
-                offset: int = 0, limit: int = None, sort: str = None, raise_on_err: bool = False) -> ReportList:
-        """ list (all) reports """
+    async def get_reports(
+        self,
+        name: str = None,
+        type: str = None,
+        sub_type: str = None,
+        state: str = None,
+        has_error: bool = None,
+        enabled: bool = None,
+        offset: int = 0,
+        limit: int = None,
+        sort: str = None,
+        raise_on_err: bool = False,
+    ) -> ReportList:
+        """list (all) reports"""
         if not await self.dracoon.test_connection() and self.dracoon.connection:
             await self.dracoon.connect(OAuth2ConnectionType.refresh_token)
 
         if self.raise_on_err:
             raise_on_err = True
 
-        api_url = self.api_url + f'/?offset={offset}'
-        if name: api_url += f'&name={name}' 
-        if limit != None: api_url += f'&limit={str(limit)}' 
-        if sort != None: api_url += f'&sort={sort}' 
-        if type != None: api_url += f'&type={type}' 
-        if sub_type != None: api_url += f'&subType={sub_type}'
-        if enabled != None: api_url += f'&type={str(enabled).lower()}' 
-        if has_error != None: api_url += f'&hasError={str(has_error).lower()}'
-        if state != None: api_url += f'&state={state}'
+        api_url = self.api_url + f"/?offset={offset}"
+        if name:
+            api_url += f"&name={name}"
+        if limit != None:
+            api_url += f"&limit={str(limit)}"
+        if sort != None:
+            api_url += f"&sort={sort}"
+        if type != None:
+            api_url += f"&type={type}"
+        if sub_type != None:
+            api_url += f"&subType={sub_type}"
+        if enabled != None:
+            api_url += f"&type={str(enabled).lower()}"
+        if has_error != None:
+            api_url += f"&hasError={str(has_error).lower()}"
+        if state != None:
+            api_url += f"&state={state}"
 
         try:
             res = await self.dracoon.http.get(self.api_url)
@@ -139,25 +180,30 @@ class DRACOONReports:
         except httpx.HTTPStatusError as e:
             self.logger.error("Getting reports failed.")
             await self.dracoon.handle_http_error(err=e, raise_on_err=raise_on_err)
-        
+
         self.logger.info("Retrieved reports.")
         return ReportList(**res.json())
 
     @retry(**RETRY_CONFIG)
-    async def delete_reports(self, report_list: List[int], raise_on_err: bool = False) -> None:
-        """ delete a list of reports (by ids) """
+    async def delete_reports(
+        self, report_list: List[int], raise_on_err: bool = False
+    ) -> None:
+        """delete a list of reports (by ids)"""
         if not await self.dracoon.test_connection() and self.dracoon.connection:
             await self.dracoon.connect(OAuth2ConnectionType.refresh_token)
 
         if self.raise_on_err:
             raise_on_err = True
 
-        payload = {
-            "ids": report_list
-        }
-        
+        payload = {"ids": report_list}
+
         try:
-            res = await self.dracoon.http.request(method='DELETE', url=self.api_url, json=payload, headers=self.dracoon.http.headers)
+            res = await self.dracoon.http.request(
+                method="DELETE",
+                url=self.api_url,
+                json=payload,
+                headers=self.dracoon.http.headers,
+            )
             res.raise_for_status()
         except httpx.RequestError as e:
             await self.dracoon.handle_connection_error(e)
@@ -170,14 +216,14 @@ class DRACOONReports:
 
     @retry(**RETRY_CONFIG)
     async def delete_report(self, report_id: int, raise_on_err: bool = False) -> None:
-        """ delete a specific report (by id) """
+        """delete a specific report (by id)"""
         if not await self.dracoon.test_connection() and self.dracoon.connection:
             await self.dracoon.connect(OAuth2ConnectionType.refresh_token)
 
         if self.raise_on_err:
             raise_on_err = True
 
-        api_url = self.api_url + f'/{str(report_id)}'
+        api_url = self.api_url + f"/{str(report_id)}"
 
         try:
             res = await self.dracoon.http.delete(api_url)
@@ -187,6 +233,6 @@ class DRACOONReports:
         except httpx.HTTPStatusError as e:
             self.logger.error("Deleting report failed.")
             await self.dracoon.handle_http_error(err=e, raise_on_err=raise_on_err)
-        
+
         self.logger.info("Deleted report.")
         return None

--- a/dracoon/reports/models.py
+++ b/dracoon/reports/models.py
@@ -3,37 +3,45 @@ from typing import List, Optional
 from datetime import datetime, time
 from enum import Enum
 
+
 class ReportType(Enum):
-    single = 'single'
-    periodic = 'periodic'
+    single = "single"
+    periodic = "periodic"
+
 
 class ReportSubType(Enum):
-    audit_report = 'general-audit-report'
-    user_activity = 'user-audit-report'
+    audit_report = "general-audit-report"
+    user_activity = "user-audit-report"
+
 
 class ReportFormat(Enum):
-    pdf = 'pdf'
-    csv = 'csv-plain'
-    csv_semicolon = 'csv-semicolon-delimited'
+    pdf = "pdf"
+    csv = "csv-plain"
+    csv_semicolon = "csv-semicolon-delimited"
+
 
 class ReportFilter(BaseModel):
-    fromDate: Optional[datetime]
-    toDate: Optional[datetime]
+    fromDate: Optional[str]
+    toDate: Optional[str]
     parentRoom: Optional[int]
     userId: Optional[int]
     operations: Optional[List[int]]
 
+
 class ReportExecutionType(Enum):
-    on_demand = 'on-demand'
-    monthly = 'monthly'
+    on_demand = "on-demand"
+    monthly = "monthly"
+
 
 class ReportExecution(BaseModel):
     type: ReportExecutionType
     timeOfDay: time
     dayOfMonth: int
 
+
 class ReportTarget(BaseModel):
     id: int
+
 
 class CreateReport(BaseModel):
     name: str
@@ -44,7 +52,6 @@ class CreateReport(BaseModel):
     formats: List[ReportFormat]
     filter: Optional[ReportFilter]
     target: ReportTarget
+
     class Config:
         use_enum_values = True
-
-


### PR DESCRIPTION
When creating a report with `from_date` and `to_date` httpx could not serialize datetime (TypeError: Object of type datetime is not JSON serializable). 

With this commit `make_report_filter()` converts datetime to isoString with a trailing "Z" to conform to the DRACOON reporting API specs.