### PR TITLE
remove trailing slashes

### DIFF
--- a/dracoon/eventlog/__init__.py
+++ b/dracoon/eventlog/__init__.py
@@ -66,7 +66,7 @@ class DRACOONEvents:
         
         if filter: filter = urllib.parse.quote(filter)
 
-        api_url = self.api_url + f'/audits/nodes/?offset={offset}'
+        api_url = self.api_url + f'/audits/nodes?offset={offset}'
         if filter != None: api_url += f'&filter={filter}' 
         if limit != None: api_url += f'&limit={str(limit)}' 
         if sort != None: api_url += f'&sort={sort}' 
@@ -97,7 +97,7 @@ class DRACOONEvents:
         
         if filter: filter = urllib.parse.quote(filter)
 
-        api_url = self.api_url + f'/audits/node_info/?parent_id={str(parent_id)}&offset={offset}'
+        api_url = self.api_url + f'/audits/node_info?parent_id={str(parent_id)}&offset={offset}'
         if filter != None: api_url += f'&filter={filter}' 
         if limit != None: api_url += f'&limit={str(limit)}' 
         if sort != None: api_url += f'&sort={sort}'
@@ -126,7 +126,7 @@ class DRACOONEvents:
         
         if filter: filter = urllib.parse.quote(filter)
 
-        api_url = self.api_url + f'/events/?offset={offset}'
+        api_url = self.api_url + f'/events?offset={offset}'
         if date_start != None: api_url += f'&date_start={date_start}'
         if date_end != None: api_url += f'&date_end={date_end}'
         if operation_id != None: api_url += f'&type={str(operation_id)}'

--- a/dracoon/groups/__init__.py
+++ b/dracoon/groups/__init__.py
@@ -101,7 +101,7 @@ class DRACOONGroups:
         
         if filter: filter = urllib.parse.quote(filter)
 
-        api_url = self.api_url + f'/?offset={offset}'
+        api_url = self.api_url + f'?offset={offset}'
         if filter != None: api_url += f'&filter={filter}' 
         if limit != None: api_url += f'&limit={str(limit)}' 
         if sort != None: api_url += f'&sort={sort}' 
@@ -211,7 +211,7 @@ class DRACOONGroups:
         
         if filter: filter = urllib.parse.quote(filter)
 
-        api_url = self.api_url + f'/{group_id}/users/?offset={str(offset)}'
+        api_url = self.api_url + f'/{group_id}/users?offset={str(offset)}'
         if filter != None: api_url += f'&filter={filter}' 
         if limit != None: api_url += f'&limit={str(limit)}' 
         if sort != None: api_url += f'&sort={sort}' 

--- a/dracoon/nodes/__init__.py
+++ b/dracoon/nodes/__init__.py
@@ -300,7 +300,7 @@ class DRACOONNodes:
     
     @retry(**RETRY_CONFIG)
     async def upload_unencrypted(self, file_path: str, upload_channel: CreateFileUploadResponse, keep_shares: bool = False, 
-                                    file_name: str = None, resolution_strategy: str = 'autorename', chunksize: int = CHUNK_SIZE, 
+                                    file_name: str = None, resolution_strategy: str = 'autorename', raise_on_err: bool = False, chunksize: int = CHUNK_SIZE, 
                                     callback_fn: Callback  = None
                                     ) -> Node:
         if self.raise_on_err:
@@ -901,7 +901,7 @@ class DRACOONNodes:
         if filter: filter = urllib.parse.quote(filter)
 
         api_url = self.api_url + \
-            f'/?offset={offset}&parent_id={str(parent_id)}&room_manager={str(room_manager).lower()}'
+            f'?offset={offset}&parent_id={str(parent_id)}&room_manager={str(room_manager).lower()}'
         if filter != None:
             api_url += f'&filter={filter}'
         if limit != None:
@@ -1006,7 +1006,7 @@ class DRACOONNodes:
             raise_on_err = True
 
         api_url = self.api_url + \
-            f'/{str(node_id)}/comments/?offset={str(offset)}'
+            f'/{str(node_id)}/comments?offset={str(offset)}'
 
         try:
             res = await self.dracoon.http.get(api_url)
@@ -1116,7 +1116,7 @@ class DRACOONNodes:
         if filter: filter = urllib.parse.quote(filter)
 
         api_url = self.api_url + \
-            f'/{str(parent_id)}/deleted_nodes/?offset={offset}'
+            f'/{str(parent_id)}/deleted_nodes?offset={offset}'
 
         if filter != None:
             api_url += f'&filter={filter}'
@@ -1489,7 +1489,7 @@ class DRACOONNodes:
 
         api_url = self.api_url + f'/files/{str(file_id)}/user_file_key'
 
-        if version: api_url += f'/?version={version}'
+        if version: api_url += f'?version={version}'
 
         try:
             res = await self.dracoon.http.get(api_url)
@@ -1653,7 +1653,7 @@ class DRACOONNodes:
         if self.raise_on_err:
             raise_on_err = True
 
-        api_url = self.api_url + f'/missingFileKeys/?offset={str(offset)}'
+        api_url = self.api_url + f'/missingFileKeys?offset={str(offset)}'
 
         if file_id != None:
             api_url += f'&file_id={str(file_id)}'
@@ -1890,7 +1890,7 @@ class DRACOONNodes:
             raise_on_err = True
 
         api_url = self.api_url + \
-            f'/rooms/{str(room_id)}/groups/?offset={str(offset)}'
+            f'/rooms/{str(room_id)}/groups?offset={str(offset)}'
         
         if filter: filter = urllib.parse.quote(filter)
 
@@ -1979,7 +1979,7 @@ class DRACOONNodes:
         if filter: filter = urllib.parse.quote(filter)
 
         api_url = self.api_url + \
-            f'/rooms/{str(room_id)}/users/?offset={str(offset)}'
+            f'/rooms/{str(room_id)}/users?offset={str(offset)}'
 
         if filter != None:
             api_url += f'&filter={filter}'
@@ -2068,7 +2068,7 @@ class DRACOONNodes:
         if filter: filter = urllib.parse.quote(filter)
 
         api_url = self.api_url + \
-            f'/rooms/{str(node_id)}/webhooks/?offset={str(offset)}'
+            f'/rooms/{str(node_id)}/webhooks?offset={str(offset)}'
 
         if filter != None:
             api_url += f'&filter={filter}'
@@ -2128,7 +2128,7 @@ class DRACOONNodes:
             
         if filter: filter = urllib.parse.quote(filter)
 
-        api_url = self.api_url + f'/rooms/{room_id}/events/?offset={str(offset)}'
+        api_url = self.api_url + f'/rooms/{room_id}/events?offset={str(offset)}'
 
         if date_start != None: api_url += f'&date_start={date_start}'
         if date_end != None: api_url += f'&date_end={date_end}'
@@ -2161,7 +2161,7 @@ class DRACOONNodes:
         if self.raise_on_err:
             raise_on_err = True
 
-        api_url = self.api_url + f'/rooms/pending/?offset={str(offset)}'
+        api_url = self.api_url + f'/rooms/pending?offset={str(offset)}'
         
         if filter: filter = urllib.parse.quote(filter)
 
@@ -2226,7 +2226,7 @@ class DRACOONNodes:
         if filter: filter = urllib.parse.quote(filter)
 
         api_url = self.api_url + \
-            f'/search/?search_string={search}&offset={str(offset)}&parent_id={str(parent_id)}&depth_level={depth_level}'
+            f'/search?search_string={search}&offset={str(offset)}&parent_id={str(parent_id)}&depth_level={depth_level}'
 
         if filter != None:
             api_url += f'&filter={filter}'

--- a/dracoon/reports/__init__.py
+++ b/dracoon/reports/__init__.py
@@ -153,7 +153,7 @@ class DRACOONReports:
         if self.raise_on_err:
             raise_on_err = True
 
-        api_url = self.api_url + f"/?offset={offset}"
+        api_url = self.api_url + f"?offset={offset}"
         if name:
             api_url += f"&name={name}"
         if limit != None:

--- a/dracoon/settings/__init__.py
+++ b/dracoon/settings/__init__.py
@@ -120,7 +120,7 @@ class DRACOONSettings:
         
         if filter: filter = urllib.parse.quote(filter)
 
-        api_url = self.api_url + f'/webhooks/?offset={offset}'
+        api_url = self.api_url + f'/webhooks?offset={offset}'
         if filter != None: api_url += f'&filter={filter}' 
         if limit != None: api_url += f'&limit={str(limit)}' 
         if sort != None: api_url += f'&sort={sort}' 

--- a/dracoon/user/__init__.py
+++ b/dracoon/user/__init__.py
@@ -66,7 +66,7 @@ class DRACOONUser:
             raise_on_err = True
 
         try:
-            api_url = self.api_url + f'/account/?more_info={str(more_info).lower()}'
+            api_url = self.api_url + f'/account?more_info={str(more_info).lower()}'
             res = await self.dracoon.http.get(api_url)
             res.raise_for_status()
         except httpx.RequestError as e:
@@ -131,7 +131,7 @@ class DRACOONUser:
             raise_on_err = True
 
         api_url = self.api_url + f'/account/keypair'
-        if version != None: api_url += '/?version=' + version.value
+        if version != None: api_url += '?version=' + version.value
 
         try:
             res = await self.dracoon.http.get(api_url)
@@ -184,7 +184,7 @@ class DRACOONUser:
             raise_on_err = True
 
         api_url = self.api_url + f'/account/keypair'
-        if version != None: api_url += '/?version=' + version.value
+        if version != None: api_url += '?version=' + version.value
 
         try:
             res = await self.dracoon.http.delete(api_url)

--- a/dracoon/users/__init__.py
+++ b/dracoon/users/__init__.py
@@ -202,7 +202,7 @@ class DRACOONUsers:
         
         if filter: filter = urllib.parse.quote(filter)
 
-        api_url = self.api_url + f'/?offset={offset}'
+        api_url = self.api_url + f'?offset={offset}'
         if filter != None: api_url += f'&filter={filter}' 
         if limit != None: api_url += f'&limit={str(limit)}' 
         if sort != None: api_url += f'&sort={sort}'
@@ -295,7 +295,7 @@ class DRACOONUsers:
         
         if filter: filter = urllib.parse.quote(filter)
 
-        api_url = self.api_url + f'/{user_id}/groups/?offset={str(offset)}'
+        api_url = self.api_url + f'/{user_id}/groups?offset={str(offset)}'
         if filter != None: api_url += f'&filter={filter}' 
         if limit != None: api_url += f'&limit={str(limit)}' 
         if sort != None: api_url += f'&sort={sort}' 
@@ -363,7 +363,7 @@ class DRACOONUsers:
         
         if filter: filter = urllib.parse.quote(filter)
 
-        api_url = self.api_url + f'/{user_id}/userAttributes/?offset={str(offset)}'
+        api_url = self.api_url + f'/{user_id}/userAttributes?offset={str(offset)}'
         if filter != None: api_url += f'&filter={filter}' 
         if limit != None: api_url += f'&limit={str(limit)}' 
         if sort != None: api_url += f'&sort={sort}' 


### PR DESCRIPTION
Since there is currently a bug and breaking change where DRACOON Core version 5.0.3 does not ignore trailing slashes on endpoints anymore, the SDK is not usable, because requests with a trailing slash will fail with status 500 and a connection cannot be made. I propose to remove them with this merge to (also) fix the problem here. 

