### PR TITLE
Bugfix/update user attributes

### DIFF
--- a/dracoon/users/__init__.py
+++ b/dracoon/users/__init__.py
@@ -402,8 +402,8 @@ class DRACOONUsers:
         return None
 
     @retry(**RETRY_CONFIG)
-    async def update_user_attributes(self, user_id: int, attributes: UpdateUserAttributes, 
-                                     raise_on_err: bool = False) -> UserData:
+    async def update_user_attributes(self, user_id: int, attributes: UpdateUserAttributes,
+                                     raise_on_err: bool = False) -> None:
         """ create / update custom user attribute for a specific user (by id) """
         if not await self.dracoon.test_connection() and self.dracoon.connection:
             await self.dracoon.connect(OAuth2ConnectionType.refresh_token)
@@ -421,7 +421,7 @@ class DRACOONUsers:
             await self.dracoon.handle_http_error(err=e, raise_on_err=raise_on_err)
 
         self.logger.info("Updated user attributes.")
-        return UserData(**res.json())
+        return None
 
     def make_custom_user_attribute(self, key: str, value: str) -> AttributeEntry:
         """ make a custom user attribute required for update_user_attributes() """

--- a/tests/test_e2e_users.py
+++ b/tests/test_e2e_users.py
@@ -200,7 +200,7 @@ class TestAsyncDRACOONUsers(unittest.IsolatedAsyncioTestCase):
         self.assertIsInstance(attributes_update, UpdateUserAttributes)
 
         attributes_update_res = await self.users.update_user_attributes(user_id=user.id, attributes=attributes_update)
-        self.assertIsInstance(attributes_update_res, UserData)
+        self.assertIsNone(attributes_update_res)
         
         user_attributes = await self.users.get_user_attributes(user_id=user.id)
         self.assertIsInstance(user_attributes, AttributesResponse)
@@ -211,7 +211,6 @@ class TestAsyncDRACOONUsers(unittest.IsolatedAsyncioTestCase):
         self.assertIsNone(attr_del)
         
         await self.users.delete_user(user_id=user.id)
-        
 class TestAsyncDRACOONServerUsers(unittest.IsolatedAsyncioTestCase):
     
     async def asyncSetUp(self) -> None:


### PR DESCRIPTION
Currently, the update_user_attributes function encounters an error due to the [DRACOON API endpoint's return type being None](https://dracoon.team/api/swagger-ui/index.html#/users/updateUserAttributes) instead of UserData. The JSON decoder fails to process a value from None, throwing an error.

Changes:
- fixed return type of update_user_attributes
- adjusted e2e test 

The e2e test before the fixed failed for me, because the JSON decoder threw an error when trying to decode a value from None. You might want to investigate why the e2e test did not fail or if a failed test went unnoticed.